### PR TITLE
Exit on failing command

### DIFF
--- a/Sources/Komondor/Commands/runner.swift
+++ b/Sources/Komondor/Commands/runner.swift
@@ -43,9 +43,12 @@ public func runner(logger _: Logger, args: [String]) throws {
             //   Store STDOUT and STDERR, and only show it if it fails
             //   Show a stepper like system of all commands
         }
+    } catch let error as ShellOutError {
+        print(error.message)
+        print(error.output)
+        exit(error.terminationStatus)
     } catch {
-        guard let error = error as? ShellOutError else { return }
-        print(error.message) // Prints STDERR
-        print(error.output) // Prints STDOUT
+        print(error)
+        exit(1)
     }
 }

--- a/Sources/Komondor/Commands/runner.swift
+++ b/Sources/Komondor/Commands/runner.swift
@@ -38,8 +38,7 @@ public func runner(logger _: Logger, args: [String]) throws {
         try commands.forEach { command in
             print("> \(command)")
             // Simple is fine for now
-            try shellOut(to: command)
-
+            print(try shellOut(to: command))
             // Ideal:
             //   Store STDOUT and STDERR, and only show it if it fails
             //   Show a stepper like system of all commands

--- a/Sources/Komondor/main.swift
+++ b/Sources/Komondor/main.swift
@@ -10,15 +10,7 @@ logger.debug("Setting up .git-hooks for Komondor (v\(KomondorVersion))")
 
 let cliLength = ProcessInfo.processInfo.arguments.count
 
-if cliLength > 1 {
-    let task = CommandLine.arguments[1]
-    if task == "install" {
-        try install(logger: logger)
-    } else if task == "run" {
-        let runnerArgs = Array(CommandLine.arguments.dropFirst().dropFirst())
-        try runner(logger: logger, args: runnerArgs)
-    }
-} else {
+guard cliLength > 1 else {
     print("""
     Welcome to Komondor, it has 2 commands:
 
@@ -27,4 +19,13 @@ if cliLength > 1 {
 
     Docs are available at: https://github.com/orta/Komondor
     """)
+    exit(0)
+}
+
+let task = CommandLine.arguments[1]
+if task == "install" {
+    try install(logger: logger)
+} else if task == "run" {
+    let runnerArgs = Array(CommandLine.arguments.dropFirst().dropFirst())
+    try runner(logger: logger, args: runnerArgs)
 }


### PR DESCRIPTION
Following on #7 this PR introduces/fixes the following behaviour:
In the case of a command failure Komondor will:
* Print the error message and exits with the error code of the failed command
* In case of any other type of error Komondor will exit with status `1` and print the raw description of the error

---
Aside from that, I introduced the following small changes:
* Make the 'happy path' more explicit by using a `guard` to check if arguments are passed or not
* The resulting value from the `try shellOut(to: command)` is printed - this is only _after_ the command has been executed.
    * ⚠️ I tried passing the correct FileHandler to shellOut in an attempt to print the output in real time, rather than after completing the action, but there are some bugs in [shellOut](https://github.com/JohnSundell/ShellOut/pull/32) that prevent us from doing this.